### PR TITLE
Fix GitHub Pages URL

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.aarnavdesigns.com


### PR DESCRIPTION
This PR removes the CNAME file to ensure the GitHub Pages site works correctly at rnavpatel.github.io/Portfolio instead of a custom domain.